### PR TITLE
add config and test for registry endpoint

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurer.java
@@ -399,6 +399,10 @@ public class KafkaSecurityConfigurer {
         configs.put(AWSSchemaRegistryConstants.CACHE_TIME_TO_LIVE_MILLIS, "86400000");
         configs.put(AWSSchemaRegistryConstants.CACHE_SIZE, "10");
         configs.put(AWSSchemaRegistryConstants.COMPATIBILITY_SETTING, Compatibility.FULL);
+        String endpointOverride = kafkaConsumerConfig.getSchemaConfig().getRegistryURL();
+        if (endpointOverride != null) {
+            configs.put(AWSSchemaRegistryConstants.AWS_ENDPOINT, endpointOverride);
+        }
         glueDeserializer = new GlueSchemaRegistryKafkaDeserializer(awsGlueCredentialsProvider, configs);
         return glueDeserializer;
     }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurerTest.java
@@ -270,6 +270,35 @@ public class KafkaSecurityConfigurerTest {
             assertThat(glueSchemaRegistryKafkaDeserializer, notNullValue());
             assertThat(glueSchemaRegistryKafkaDeserializer.getCredentialProvider(),
                     instanceOf(DefaultCredentialsProvider.class));
+            assertThat(glueSchemaRegistryKafkaDeserializer
+                    .getGlueSchemaRegistryDeserializationFacade()
+                    .getGlueSchemaRegistryConfiguration()
+                    .getEndPoint(), is(nullValue()));
+        }
+    }
+
+    @Test
+    void testGetGlueSerializerWithDefaultCredentialsProviderAndOverrridenRegistryEndpoint() throws IOException {
+        final KafkaSourceConfig kafkaSourceConfig = createKafkaSinkConfig(
+                "kafka-pipeline-bootstrap-servers-glue-override-endpoint.yaml");
+        final DefaultAwsRegionProviderChain.Builder defaultAwsRegionProviderChainBuilder = mock(
+                DefaultAwsRegionProviderChain.Builder.class);
+        final DefaultAwsRegionProviderChain defaultAwsRegionProviderChain = mock(DefaultAwsRegionProviderChain.class);
+        when(defaultAwsRegionProviderChainBuilder.build()).thenReturn(defaultAwsRegionProviderChain);
+        when(defaultAwsRegionProviderChain.getRegion()).thenReturn(Region.US_EAST_1);
+        try (MockedStatic<DefaultAwsRegionProviderChain> defaultAwsRegionProviderChainMockedStatic =
+                     mockStatic(DefaultAwsRegionProviderChain.class)) {
+            defaultAwsRegionProviderChainMockedStatic.when(DefaultAwsRegionProviderChain::builder)
+                    .thenReturn(defaultAwsRegionProviderChainBuilder);
+            final GlueSchemaRegistryKafkaDeserializer glueSchemaRegistryKafkaDeserializer = KafkaSecurityConfigurer
+                    .getGlueSerializer(kafkaSourceConfig);
+            assertThat(glueSchemaRegistryKafkaDeserializer, notNullValue());
+            assertThat(glueSchemaRegistryKafkaDeserializer.getCredentialProvider(),
+                    instanceOf(DefaultCredentialsProvider.class));
+            assertThat(glueSchemaRegistryKafkaDeserializer
+                    .getGlueSchemaRegistryDeserializationFacade()
+                    .getGlueSchemaRegistryConfiguration()
+                    .getEndPoint(), is("http://fake-glue-registry"));
         }
     }
 

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-bootstrap-servers-glue-override-endpoint.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-bootstrap-servers-glue-override-endpoint.yaml
@@ -1,0 +1,15 @@
+log-pipeline :
+  source:
+     kafka:
+        bootstrap_servers:
+          - "localhost:9092"
+        encryption:
+          type: "SSL"
+        schema:
+          type: aws_glue
+          registry_url: http://fake-glue-registry
+        topics:
+        - name: "quickstart-events"
+          group_id: "groupdID1"
+  sink:
+    stdout:


### PR DESCRIPTION
### Description
Add support for the kafka.schema.registry_url setting for the aws_glue schema registry.  Previously this setting was ignored and the code would only connect to the standard aws glue registry endpoint.  This change allows for running a local aws glue registry using something like localstack or motoserver so that local integration testing can occur.  We noticed this problem when setting up AWS OSIS and being unable to locally perform integration testing in our application.
 
### Issues Resolved
Resolves #[5377]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
